### PR TITLE
Adding a requirements text file for Vagrant and an __init__.py file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask==1.0.2
+Flask-API==1.1
+Flask-SQLAlchemy==2.3.2
+nose==1.3.7
+pinocchio==0.4.2
+coverage==4.5.2


### PR DESCRIPTION
Tested Vagrant up and it failed because of not having requirement text file. So added that. Also added__init__.py which is necessary for running python files